### PR TITLE
code is an optional argument to find()

### DIFF
--- a/ds_store/store.py
+++ b/ds_store/store.py
@@ -1146,7 +1146,7 @@ class DSStore(object):
 
     # Find implementation
     def _find(self, node, filename_lc, code=None):
-        if not isinstance(code, bytes):
+        if code is not None and not isinstance(code, bytes):
             code = code.encode('latin_1')
         with self._get_block(node) as block:
             next_node, count = block.read(b'>II')

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -35,3 +35,11 @@ def test_holds_data(tmpdir):
         assert store['foobar.dat']['note'] == (b'ustr', u'Hello World!')
 
     os.unlink(store_name)
+
+def test_find(tmpdir):
+    """Test that we can find records with and without a code"""
+    with DSStore.open('tests/Test_DS_Store', 'r') as store:
+        bamIloc = list(store.find('bam',code='Iloc'))
+        assert len(bamIloc) == 1
+        bam = list(store.find('bam'))
+        assert bamIloc == bam


### PR DESCRIPTION
Calling `find()` without passing the optional argument `code` will raise the exception `AttributeError: 'NoneType' object has no attribute 'encode'`